### PR TITLE
게시판 api 만들기 - Data Rest 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/project/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/project/projectboard/repository/ArticleCommentRepository.java
@@ -2,8 +2,9 @@ package com.project.projectboard.repository;
 
 import com.project.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
-@Repository
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/src/main/java/com/project/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/project/projectboard/repository/ArticleRepository.java
@@ -2,8 +2,9 @@ package com.project.projectboard.repository;
 
 import com.project.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.stereotype.Repository;
 
-@Repository
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,3 +22,7 @@ spring:
       hibernate.default_batch_fetch_size: 100
   h2.console.enabled: true
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
+

--- a/src/test/java/com/project/projectboard/controller/DataRestTests.java
+++ b/src/test/java/com/project/projectboard/controller/DataRestTests.java
@@ -1,0 +1,49 @@
+package com.project.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.transaction.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data Rest 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTests {
+
+    private final MockMvc mvc;
+
+    public DataRestTests(@Autowired MockMvc mvc){
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void test() throws Exception {
+
+        mvc.perform( get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnArticleCommentsJsonResponse() throws Exception {
+
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
게시글 / 댓글은 간편하게 Spring boot DATA Rest로 서비스하고, 해당 API들의 존재여부 체크